### PR TITLE
Add NotFound component with catch-all route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import Home from './pages/Home';
 import About from './pages/About';
 import Services from './pages/Services';
 import Contact from './pages/Contact';
+import NotFound from './pages/NotFound';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
         <Route path="about" element={<About />} />
         <Route path="services" element={<Services />} />
         <Route path="contact" element={<Contact />} />
+        <Route path="*" element={<NotFound />} />
       </Route>
     </Routes>
   );

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import Button from '../components/common/Button';
+
+const NotFound: React.FC = () => {
+  useEffect(() => {
+    document.title = '404 | Ballast Financial';
+    window.scrollTo(0, 0);
+  }, []);
+
+  return (
+    <div className="pt-24 text-center px-4">
+      <h1 className="text-4xl md:text-5xl font-bold mb-4 text-primary-500">
+        Page Not Found
+      </h1>
+      <p className="text-lg text-primary-500/80 mb-8">
+        Sorry, the page you're looking for does not exist.
+      </p>
+      <Button variant="primary" size="lg" to="/">
+        Back to Home
+      </Button>
+    </div>
+  );
+};
+
+export default NotFound;


### PR DESCRIPTION
## Summary
- create a 404 page component with a friendly message
- register the component as `path="*"` in the router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*