### PR TITLE
Fix testimonial quote, add tests, and improve docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,20 @@
 # sb1-vkn8ybmo
 
+Demo project for a financial services website built with React and Vite.
+
 [Edit in StackBlitz next generation editor ⚡️](https://stackblitz.com/~/github.com/uopcoffee/sb1-vkn8ybmo)
+
+## Getting Started
+
+Install dependencies and start the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+To create a production build:
+
+```bash
+npm run build
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,10 @@
         "tailwindcss": "^3.4.1",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
-        "vite": "^5.4.2"
+        "vite": "^5.4.2",
+        "vitest": "^1.3.0",
+        "@testing-library/react": "^14.1.2",
+        "@testing-library/jest-dom": "^6.1.5"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",
@@ -30,6 +31,9 @@
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
-    "vite": "^5.4.2"
+    "vite": "^5.4.2",
+    "vitest": "^1.3.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.5"
   }
 }

--- a/src/components/common/Button.test.tsx
+++ b/src/components/common/Button.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import Button from './Button';
+
+describe('Button', () => {
+  it('renders children', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByText('Click me')).toBeInTheDocument();
+  });
+
+  it('applies primary variant classes', () => {
+    render(<Button variant="primary">Primary</Button>);
+    const btn = screen.getByText('Primary');
+    expect(btn.className).toContain('bg-accent-500');
+  });
+});

--- a/src/components/services/TestimonialCarousel.tsx
+++ b/src/components/services/TestimonialCarousel.tsx
@@ -36,7 +36,7 @@ const TestimonialCarousel: React.FC = () => {
               </div>
               <div>
                 <p className="text-xl md:text-2xl italic text-primary-500 mb-6">
-                  “{testimonial.quote}”
+                  {testimonial.quote}
                 </p>
                 <div>
                   <p className="font-bold text-primary-500">{testimonial.author}</p>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,4 +11,8 @@ export default defineConfig({
     host: true, // Listen on all local IPs
     port: 5173,
   },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+  },
 });


### PR DESCRIPTION
## Summary
- show testimonial quote text without literal quotes
- document setup commands in `README`
- configure Vitest and add a simple button test

## Testing
- `npm test` *(fails: vitest not found)*