### PR TITLE
Add setup script for jsdom

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -euo pipefail
+# Install Node dependencies from package-lock.json
+npm ci
+# vitest expects jsdom as a peer dependency
+npm install --no-save jsdom


### PR DESCRIPTION
## Summary
- add `setup.sh` to ensure vitest has jsdom dependency

## Confirm
- [x] Lint passes
- [x] Tests pass
- [x] No secrets or keys added

Suggested reviewers: @uopcoffee