### PR TITLE
Integrate contact form backend

### DIFF
--- a/src/components/common/Toast.tsx
+++ b/src/components/common/Toast.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+
+interface ToastProps {
+  message: string;
+  onClose: () => void;
+  duration?: number;
+}
+
+const Toast: React.FC<ToastProps> = ({ message, onClose, duration = 3000 }) => {
+  useEffect(() => {
+    const timer = setTimeout(onClose, duration);
+    return () => clearTimeout(timer);
+  }, [onClose, duration]);
+
+  return (
+    <div className="fixed top-4 right-4 bg-accent-500 text-white px-4 py-2 rounded shadow-lg">
+      {message}
+    </div>
+  );
+};
+
+export default Toast;

--- a/src/components/contact/ContactForm.test.tsx
+++ b/src/components/contact/ContactForm.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import '@testing-library/jest-dom/vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import ContactForm from './ContactForm';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('ContactForm', () => {
+  it('shows validation errors for empty fields', async () => {
+    render(<ContactForm />);
+    fireEvent.submit(screen.getByRole('button', { name: /send message/i }));
+    const alerts = await screen.findAllByRole('alert');
+    expect(alerts).toHaveLength(4);
+  });
+
+  it('submits form and displays toast', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<ContactForm />);
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'A' } });
+    fireEvent.change(screen.getByLabelText(/email/i), { target: { value: 'a@example.com' } });
+    fireEvent.change(screen.getByLabelText(/company/i), { target: { value: 'Acme' } });
+    fireEvent.change(screen.getByLabelText(/message/i), { target: { value: 'Hello' } });
+
+    fireEvent.submit(screen.getByRole('button', { name: /send message/i }));
+
+    await screen.findByText(/message sent successfully/i);
+    expect(fetchMock).toHaveBeenCalledWith('/api/contact', expect.any(Object));
+  });
+});

--- a/src/components/contact/ContactForm.tsx
+++ b/src/components/contact/ContactForm.tsx
@@ -1,66 +1,141 @@
 import React, { useState } from 'react';
 import Button from '../common/Button';
+import Toast from '../common/Toast';
+
+interface FormData {
+  name: string;
+  email: string;
+  company: string;
+  message: string;
+}
+
+interface FormErrors {
+  name?: string;
+  email?: string;
+  company?: string;
+  message?: string;
+}
 
 const ContactForm: React.FC = () => {
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<FormData>({
     name: '',
     email: '',
     company: '',
-    message: ''
+    message: '',
   });
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const validate = (): FormErrors => {
+    const newErrors: FormErrors = {};
+    if (!formData.name.trim()) newErrors.name = 'Name is required';
+    if (!formData.email.trim()) {
+      newErrors.email = 'Email is required';
+    } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(formData.email)) {
+      newErrors.email = 'Email is invalid';
+    }
+    if (!formData.company.trim()) newErrors.company = 'Company is required';
+    if (!formData.message.trim()) newErrors.message = 'Message is required';
+    return newErrors;
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    // Form submission logic here
-    console.log('Form submitted:', formData);
+    const validationErrors = validate();
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors);
+      return;
+    }
+
+    setErrors({});
+    setIsSubmitting(true);
+
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData),
+      });
+      if (!res.ok) {
+        throw new Error('Request failed');
+      }
+      setToast('Message sent successfully');
+      setFormData({ name: '', email: '', company: '', message: '' });
+    } catch {
+      setToast('There was a problem submitting the form');
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
     <div className="bg-white rounded-lg shadow-lg p-8">
+      {toast && <Toast message={toast} onClose={() => setToast(null)} />}
       <h2 className="text-2xl font-bold mb-6">Send Us a Message</h2>
       <form onSubmit={handleSubmit} className="space-y-6">
         <div>
-          <label className="block text-sm font-medium mb-2">Name</label>
+          <label htmlFor="name" className="block text-sm font-medium mb-2">Name</label>
           <input
+            id="name"
             type="text"
             value={formData.name}
             onChange={(e) => setFormData({ ...formData, name: e.target.value })}
             className="w-full px-4 py-2 rounded-lg border focus:ring-2 focus:ring-primary-500"
-            required
           />
+          {errors.name && (
+            <p className="text-red-500 text-sm mt-1" role="alert">
+              {errors.name}
+            </p>
+          )}
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-2">Email</label>
+          <label htmlFor="email" className="block text-sm font-medium mb-2">Email</label>
           <input
+            id="email"
             type="email"
             value={formData.email}
             onChange={(e) => setFormData({ ...formData, email: e.target.value })}
             className="w-full px-4 py-2 rounded-lg border focus:ring-2 focus:ring-primary-500"
-            required
           />
+          {errors.email && (
+            <p className="text-red-500 text-sm mt-1" role="alert">
+              {errors.email}
+            </p>
+          )}
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-2">Company</label>
+          <label htmlFor="company" className="block text-sm font-medium mb-2">Company</label>
           <input
+            id="company"
             type="text"
             value={formData.company}
             onChange={(e) => setFormData({ ...formData, company: e.target.value })}
             className="w-full px-4 py-2 rounded-lg border focus:ring-2 focus:ring-primary-500"
-            required
           />
+          {errors.company && (
+            <p className="text-red-500 text-sm mt-1" role="alert">
+              {errors.company}
+            </p>
+          )}
         </div>
 
         <div>
-          <label className="block text-sm font-medium mb-2">Message</label>
+          <label htmlFor="message" className="block text-sm font-medium mb-2">Message</label>
           <textarea
+            id="message"
             value={formData.message}
             onChange={(e) => setFormData({ ...formData, message: e.target.value })}
             className="w-full px-4 py-2 rounded-lg border focus:ring-2 focus:ring-primary-500"
             rows={4}
-            required
           />
+          {errors.message && (
+            <p className="text-red-500 text-sm mt-1" role="alert">
+              {errors.message}
+            </p>
+          )}
         </div>
 
         <Button
@@ -68,8 +143,9 @@ const ContactForm: React.FC = () => {
           variant="primary"
           size="lg"
           className="w-full"
+          disabled={isSubmitting}
         >
-          Send Message
+          {isSubmitting ? 'Sending...' : 'Send Message'}
         </Button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add simple Toast component
- connect ContactForm to POST `/api/contact`
- validate fields with inline errors
- show toast and loading state on submit
- test ContactForm interactions

## Testing
- `npm run lint -- --fix`
- `npm test -- -w=false`
