### PR TITLE
Add Meta component and enrich service content

### DIFF
--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from 'react';
+
+interface MetaProps {
+  title?: string;
+  description?: string;
+}
+
+const Meta: React.FC<MetaProps> = ({ title, description }) => {
+  useEffect(() => {
+    if (title) {
+      document.title = title;
+      const ogTitle = document.querySelector('meta[property="og:title"]');
+      if (ogTitle) {
+        ogTitle.setAttribute('content', title);
+      }
+    }
+    if (description) {
+      let meta = document.querySelector('meta[name="description"]');
+      if (!meta) {
+        meta = document.createElement('meta');
+        meta.setAttribute('name', 'description');
+        document.head.appendChild(meta);
+      }
+      meta.setAttribute('content', description);
+      const ogDesc = document.querySelector('meta[property="og:description"]');
+      if (ogDesc) {
+        ogDesc.setAttribute('content', description);
+      }
+    }
+  }, [title, description]);
+
+  return null;
+};
+
+export default Meta;

--- a/src/components/home/ServicesGrid.tsx
+++ b/src/components/home/ServicesGrid.tsx
@@ -13,7 +13,8 @@ const services: Service[] = [
   {
     icon: <BookOpen className="w-12 h-12 text-primary-700 stroke-[2]" />,
     title: "Accounting Operations",
-    description: "Monthly bookkeeping and GAAP financial reporting",
+    description:
+      "Monthly bookkeeping and GAAP financial reporting. We reconcile accounts, handle accruals and deliver investor-ready statements.",
     details: [
       "Monthly close process",
       "Financial statement preparation",
@@ -24,7 +25,8 @@ const services: Service[] = [
   {
     icon: <Handshake className="w-12 h-12 text-accent-700 stroke-[2]" />,
     title: "Vendor Management",
-    description: "Vendor onboarding, contract management and payment processing",
+    description:
+      "Vendor onboarding, contract management and payment processing. Our controls ensure compliance and optimize spend across your supply chain.",
     details: [
       "Vendor selection and onboarding",
       "Contract negotiation",
@@ -35,7 +37,8 @@ const services: Service[] = [
   {
     icon: <TrendingUp className="w-12 h-12 text-primary-700 stroke-[2]" />,
     title: "FP&A",
-    description: "Budgeting, forecasting and KPI analysis",
+    description:
+      "Budgeting, forecasting and KPI analysis that puts data behind every decision. Our reporting gives clarity from boardroom to runway.",
     details: [
       "Budgeting and forecasting",
       "KPI tracking and analysis",
@@ -46,7 +49,8 @@ const services: Service[] = [
   {
     icon: <Lightbulb className="w-12 h-12 text-accent-700 stroke-[2]" />,
     title: "Special Projects",
-    description: "Support for due diligence, system builds and other projects",
+    description:
+      "Support for due diligence, system builds and other projects. We lead integrations and process improvements to keep finance moving forward.",
     details: [
       "Due diligence support",
       "System implementations",

--- a/src/components/services/CaseStudies.tsx
+++ b/src/components/services/CaseStudies.tsx
@@ -21,8 +21,10 @@ const caseStudies: CaseStudy[] = [
     industry: 'SaaS',
     serviceAreas: ['ERP Implementation', 'Fundraising Readiness'],
     companySize: '100–200 employees',
-    challenge: 'Execute dual-track ERP implementation while maintaining audit-ready financials during capital raise.',
-    solution: 'Implemented parallel workstreams for ERP deployment and fundraising preparation.',
+    challenge:
+      'Execute dual-track ERP implementation while maintaining audit-ready financials during capital raise.',
+    solution:
+      'Implemented parallel workstreams for ERP deployment and fundraising preparation. Finance remained close-ready every month.',
     result: 'On-time ERP launch, uninterrupted investor reporting, improved month-end close.',
     icon: <Building2 className="w-8 h-8" />
   },
@@ -32,8 +34,10 @@ const caseStudies: CaseStudy[] = [
     industry: 'Agri-Food',
     serviceAreas: ['Government Compliance', 'Capital Project Management'],
     companySize: '50–100 employees',
-    challenge: 'Manage USDA-funded R&D facility build while ensuring compliance and tax credit capture.',
-    solution: 'Developed comprehensive project management and compliance tracking system.',
+    challenge:
+      'Manage USDA-funded R&D facility build while ensuring compliance and tax credit capture.',
+    solution:
+      'Developed comprehensive project management and compliance tracking system, giving stakeholders real-time visibility.',
     result: 'Timely loan drawdowns, full credit capture, real-time spend visibility.',
     icon: <Leaf className="w-8 h-8" />
   },
@@ -43,8 +47,10 @@ const caseStudies: CaseStudy[] = [
     industry: 'Aerospace',
     serviceAreas: ['P2P Systems', 'Budget Controls'],
     companySize: '100–200 employees',
-    challenge: 'Scale procurement processes while maintaining tight budget control.',
-    solution: 'Implemented 3-way match and BvA-enabled procure-to-pay system.',
+    challenge:
+      'Scale procurement processes while maintaining tight budget control.',
+    solution:
+      'Implemented 3-way match and BvA-enabled procure-to-pay system for full spending oversight.',
     result: 'Streamlined purchasing, tighter budget control, audit-friendly systems.',
     icon: <Rocket className="w-8 h-8" />
   },
@@ -54,8 +60,10 @@ const caseStudies: CaseStudy[] = [
     industry: 'AI/ML',
     serviceAreas: ['M&A Advisory', 'Global Entity Management'],
     companySize: '150–300 employees',
-    challenge: 'Navigate complex acquisition preparation and foreign entity restructuring.',
-    solution: 'Led comprehensive M&A readiness and global entity optimization.',
+    challenge:
+      'Navigate complex acquisition preparation and foreign entity restructuring.',
+    solution:
+      'Led comprehensive M&A readiness and global entity optimization to support expansion plans.',
     result: 'Seamless financial transition, no reporting disruptions, leadership acclaim.',
     icon: <Cpu className="w-8 h-8" />
   },
@@ -66,7 +74,8 @@ const caseStudies: CaseStudy[] = [
     serviceAreas: ['ASC 805', 'Carve-Out Support'],
     companySize: '100–200 employees',
     challenge: 'Complex acquisition accounting and regulatory compliance needs.',
-    solution: 'Executed purchase price allocation and ASC 805 compliance protocols.',
+    solution:
+      'Executed purchase price allocation and ASC 805 compliance protocols with seamless integration into existing processes.',
     result: 'Clean execution with zero audit flags and continuity of operations.',
     icon: <Factory className="w-8 h-8" />
   },
@@ -77,7 +86,8 @@ const caseStudies: CaseStudy[] = [
     serviceAreas: ['Global Startup Setup', 'Tax Coordination'],
     companySize: '11–50 employees',
     challenge: 'Launch global operations with complex international tax requirements.',
-    solution: 'Established comprehensive financial infrastructure and tax framework.',
+    solution:
+      'Established comprehensive financial infrastructure and tax framework enabling cross-border expansion.',
     result: 'Infrastructure in place pre-funding; led to $60M raise from top investors.',
     icon: <Briefcase className="w-8 h-8" />
   },
@@ -88,7 +98,8 @@ const caseStudies: CaseStudy[] = [
     serviceAreas: ['ASC 606 Compliance', 'Interim Finance Leadership'],
     companySize: '11–50 employees',
     challenge: 'Upgrade technical accounting while maintaining operational stability.',
-    solution: 'Implemented ASC 606 compliance framework while managing daily operations.',
+    solution:
+      'Implemented ASC 606 compliance framework while managing daily operations, positioning the company for a smooth audit.',
     result: 'Financial stability, clean audit path, and readiness for capital raise.',
     icon: <Code className="w-8 h-8" />
   },
@@ -99,7 +110,8 @@ const caseStudies: CaseStudy[] = [
     serviceAreas: ['Billing Infrastructure', 'Supply Chain Readiness'],
     companySize: '10–50 employees',
     challenge: 'Scale billing and supply chain systems for major OEM contract.',
-    solution: 'Developed enterprise-grade billing and P2P infrastructure.',
+    solution:
+      'Developed enterprise-grade billing and P2P infrastructure with controls built for enterprise partnerships.',
     result: 'Operational readiness and billing reliability meeting multinational standards.',
     icon: <Leaf className="w-8 h-8" />
   },
@@ -110,7 +122,8 @@ const caseStudies: CaseStudy[] = [
     serviceAreas: ['Litigation Support', 'Crisis Advisory'],
     companySize: '~350 employees',
     challenge: 'Navigate contract litigation while maintaining business operations.',
-    solution: 'Implemented robust documentation protocols and advisory support.',
+    solution:
+      'Implemented robust documentation protocols and advisory support to reduce risk while staying market-facing.',
     result: 'Stabilized operations, retained market presence, managed reputational risk.',
     icon: <Coffee className="w-8 h-8" />
   }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,21 +1,20 @@
 import React, { useEffect } from 'react';
-import { setMeta } from '../utils/seo';
+import Meta from '../components/Meta';
 import { motion } from 'framer-motion';
 import Section from '../components/common/Section';
 import Button from '../components/common/Button';
 
 const About: React.FC = () => {
   useEffect(() => {
-    setMeta({
-      title: 'About – Ballast Financial | Startup CFO & Accounting',
-      description:
-        'Learn about our mission and team. Ballast Financial provides outsourced CFO services and financial operations for growth-focused startups.',
-    });
     window.scrollTo(0, 0);
   }, []);
 
   return (
     <div className="pt-24">
+      <Meta
+        title="About – Ballast Financial | Startup CFO & Accounting"
+        description="Learn about our mission and team. Ballast Financial provides outsourced CFO services and financial operations for growth-focused startups."
+      />
       {/* Hero Section */}
       <section className="py-20 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-primary-600 to-primary-700 opacity-95" />

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { setMeta } from '../utils/seo';
+import Meta from '../components/Meta';
 import { motion } from 'framer-motion';
 import ContactForm from '../components/contact/ContactForm';
 import CalendlyEmbed from '../components/contact/CalendlyEmbed';
@@ -8,16 +8,15 @@ import Button from '../components/common/Button';
 
 const Contact: React.FC = () => {
   useEffect(() => {
-    setMeta({
-      title: 'Contact – Ballast Financial | Startup CFO & Accounting',
-      description:
-        'Get in touch with Ballast Financial for expert startup finance guidance. Schedule a consultation or message our team today.',
-    });
     window.scrollTo(0, 0);
   }, []);
 
   return (
     <div className="pt-24">
+      <Meta
+        title="Contact – Ballast Financial | Startup CFO & Accounting"
+        description="Get in touch with Ballast Financial for expert startup finance guidance. Schedule a consultation or message our team today."
+      />
       {/* Hero Section */}
       <section className="py-20 relative overflow-hidden">
         <div 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { setMeta } from '../utils/seo';
+import Meta from '../components/Meta';
 import Hero from '../components/home/Hero';
 import HowItWorks from '../components/home/HowItWorks';
 import WhyChoose from '../components/home/WhyChoose';
@@ -8,16 +8,15 @@ import BottomCTA from '../components/home/BottomCTA';
 
 const Home: React.FC = () => {
   useEffect(() => {
-    setMeta({
-      title: 'Ballast Financial – Startup CFO & Accounting Services',
-      description:
-        'Outsourced CFO, accounting, and finance operations for venture-backed startups. Ballast Financial streamlines your financial processes and provides steady guidance so you can scale with confidence.',
-    });
     window.scrollTo(0, 0);
   }, []);
 
   return (
     <>
+      <Meta
+        title="Ballast Financial – Startup CFO & Accounting Services"
+        description="Outsourced CFO, accounting, and finance operations for venture-backed startups. Ballast Financial streamlines your financial processes and provides steady guidance so you can scale with confidence."
+      />
       <Hero />
       <HowItWorks />
       <WhyChoose />

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,18 +1,15 @@
 import React, { useEffect } from 'react';
-import { setMeta } from '../utils/seo';
+import Meta from '../components/Meta';
 import Button from '../components/common/Button';
 
 const NotFound: React.FC = () => {
   useEffect(() => {
-    setMeta({
-      title: '404 – Ballast Financial',
-      description: 'The page you are looking for does not exist.',
-    });
     window.scrollTo(0, 0);
   }, []);
 
   return (
     <div className="pt-24 text-center px-4">
+      <Meta title="404 – Ballast Financial" description="The page you are looking for does not exist." />
       <h1 className="text-4xl md:text-5xl font-bold mb-4 text-primary-500">
         Page Not Found
       </h1>

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { setMeta } from '../utils/seo';
+import Meta from '../components/Meta';
 import { motion } from 'framer-motion';
 import Section from '../components/common/Section';
 import ServicesGrid from '../components/home/ServicesGrid';
@@ -8,16 +8,15 @@ import ServicesCTA from '../components/services/ServicesCTA';
 
 const Services: React.FC = () => {
   useEffect(() => {
-    setMeta({
-      title: 'Services – Ballast Financial | Startup Finance & Accounting',
-      description:
-        'Explore our outsourced CFO, accounting, and finance services built for venture-backed startups. Let Ballast streamline your books and reporting.',
-    });
     window.scrollTo(0, 0);
   }, []);
 
   return (
     <div className="pt-24">
+      <Meta
+        title="Services – Ballast Financial | Startup Finance & Accounting"
+        description="Explore our outsourced CFO, accounting, and finance services built for venture-backed startups. Let Ballast streamline your books and reporting."
+      />
       {/* Hero Section */}
       <section className="py-20 relative overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-primary-600 to-primary-700 opacity-95" />


### PR DESCRIPTION
## Summary
- add reusable `Meta` component for setting page metadata
- replace per-page `setMeta` calls with `<Meta>`
- expand services blurbs and case study details

## Testing
- `npx eslint . --fix`
- `npx vitest run`